### PR TITLE
Use GitHub releases for esptool2, add osx binary for esptool2.

### DIFF
--- a/arduino/package_gpnbadge_index.json
+++ b/arduino/package_gpnbadge_index.json
@@ -156,11 +156,18 @@
       "name": "esptool2",
       "systems": [
         {
-          "url": "https://public.electronics.fail/esptool2-1.0.0-linux64.tar.gz",
+          "url": "https://github.com/kleinmann/esptool2/releases/download/1.0.0/esptool2-1.0.0-linux64.tar.gz",
           "checksum": "SHA-256:2623da7f9eb9c4b7d96beb31c1a53f584b5d9457361a11e886e19febcab0df1e",
           "host": "x86_64-pc-linux-gnu",
           "archiveFileName": "esptool2-1.0.0-linux64.tar.gz",
           "size": "8856"
+        },
+        {
+          "url": "https://github.com/kleinmann/esptool2/releases/download/1.0.0/esptool2-1.0.0-osx.tar.gz",
+          "checksum": "SHA-256:270183465fa7d7dd6c7b77c045410a42d2882517ff7586e5c9f83ff757492d31",
+          "host": "x86_64-apple-darwin",
+          "archiveFileName": "esptool2-1.0.0-osx.tar.gz",
+          "size": "6389"
         }
       ]
     },


### PR DESCRIPTION
I have forked esptool2 and added a GitHub release, using your linux64 binary and an osx binary I just compiled on OSX 10.12.4. This was a PoC to see if I can then load the board definition in Arduino IDE for OSX.

It might be best if the entropia org forked raburton/esptool2 and hosted the binaries themselves or if the osx binary is just added to public.electronics.fail to fix osx compatibility.

Just let me know or edit the PR :-)