### PR TITLE
Added esptool2 linux32 release

### DIFF
--- a/arduino/package_gpnbadge_index.json
+++ b/arduino/package_gpnbadge_index.json
@@ -156,6 +156,13 @@
       "name": "esptool2",
       "systems": [
         {
+          "url": "https://github.com/orithena/esptool2/releases/download/1.0.0/esptool2-1.0.0-linux32.tar.gz",
+          "checksum": "SHA-256:3ecca9cc20c1195356a622bf8150bdd34a815f8a72677cab0b6396dee5bab20c",
+          "host": "i686-pc-linux-gnu",
+          "archiveFileName": "esptool2-1.0.0-linux32.tar.gz",
+          "size": "8889"
+        },
+        {
           "url": "https://github.com/kleinmann/esptool2/releases/download/1.0.0/esptool2-1.0.0-linux64.tar.gz",
           "checksum": "SHA-256:2623da7f9eb9c4b7d96beb31c1a53f584b5d9457361a11e886e19febcab0df1e",
           "host": "x86_64-pc-linux-gnu",


### PR DESCRIPTION
Added esptool2 linux32 build (points to my fork of raburton/esptool2 ... I changed nothing, I simply created a binary for linux32 from it and uploaded it as a release file).